### PR TITLE
Handle build setup directory name better

### DIFF
--- a/bin/find_j5_src.ps1
+++ b/bin/find_j5_src.ps1
@@ -1,0 +1,12 @@
+Set-Location -Path $PSScriptRoot
+$src_dir = @((Get-ChildItem ..\..\*\j5\src\j5-app.yml).Directory.Parent.Parent.FullName)
+if ($src_dir.Length -eq 0) {
+  Write-Warning "Could not find j5 source directory"
+  [Environment]::Exit(1)
+} elseif ($src_dir.Length -eq 1) {
+  Write-Host $src_dir
+} else {
+  $host.ui.WriteErrorLine("Found multiple j5 source directories. Cannot determine which to activate")
+  ForEach ($d in $src_dir) { $host.ui.WriteErrorLine($d) }
+  [Environment]::Exit(1)
+}

--- a/bin/find_j5_src.ps1
+++ b/bin/find_j5_src.ps1
@@ -1,12 +1,12 @@
 Set-Location -Path $PSScriptRoot
 $src_dir = @((Get-ChildItem ..\..\*\j5\src\j5-app.yml).Directory.Parent.Parent.FullName)
 if ($src_dir.Length -eq 0) {
-  Write-Warning "Could not find j5 source directory"
+  Write-Warning "Could not locate j5 framework"
   [Environment]::Exit(1)
 } elseif ($src_dir.Length -eq 1) {
   Write-Host $src_dir
 } else {
-  $host.ui.WriteErrorLine("Found multiple j5 source directories. Cannot determine which to activate")
+  $host.ui.WriteErrorLine("Found multiple j5 framework directories. Cannot determine which to activate")
   ForEach ($d in $src_dir) { $host.ui.WriteErrorLine($d) }
   [Environment]::Exit(1)
 }

--- a/bin/j5activate.cmd
+++ b/bin/j5activate.cmd
@@ -6,15 +6,35 @@ if "%1"=="/h" goto usage
 
 if [%1]==[] goto nolabel
 
-call "%~dp0\..\..\j5-framework-%1\j5\src\Scripts\helpers\j5activate.cmd"
-
-goto :eof
+set src_dir="%~dp0\..\..\j5-framework-%1"
+goto :activate
 
 :nolabel
 
-call "%~dp0\..\..\j5-framework\j5\src\Scripts\helpers\j5activate.cmd"
+set src_dir="%~dp0\..\..\j5-framework"
+if exist "%src_dir%" goto :activate
 
+set tmpfile="%tmp%\j5path_%RANDOM%.txt"
+powershell -NoProfile -ExecutionPolicy unrestricted -File "%~dp0\find_j5_src.ps1" > "%tmpfile%"
+set failure=%errorlevel%
+if %failure% neq 0 (
+  type "%tmpfile%" >&2
+  del "%tmpfile%"
+  goto :error
+)
+set /p src_dir=<%tmpfile%
+del "%tmpfile%"
+echo Found source directory at %src_dir%
+
+goto :activate
+
+:activate
+call "%src_dir%\j5\src\Scripts\helpers\j5activate.cmd"
 goto :eof
 
 :usage
 @echo syntax j5activate [framework-src-label]
+goto :eof
+
+:error
+exit 1

--- a/helpers/enable-j5-activate.sh
+++ b/helpers/enable-j5-activate.sh
@@ -13,6 +13,24 @@ _this_script="`readlink -f "$BASH_SOURCE"`"
 j5activate() {
     if [ "$#" == 0 ]; then
         J5DIR=$J5_PARENT_GIT_DIR/j5-framework/j5/src/
+        if [ ! -d "$J5DIR" ]; then
+           src_markers=($J5_PARENT_GIT_DIR/*/j5/src/j5-app.yml)
+           if [ "${#src_markers[@]}" == 1 ] && [ -f "${src_markers[0]}" ]; then
+               J5DIR="`dirname "${src_markers[0]}"`"
+               colored_echo blue "Found j5 framework at $J5DIR" >&2
+           elif [ "${#src_markers[@]}" == 0 ] || [ ! -f "${src_markers[0]}" ]; then
+               colored_echo red "Could not locate j5 framework - $J5DIR does not exist" >&2
+               return 1
+           else
+               colored_echo red "Found multiple j5 framework directories. Cannot determine which to activate" >&2
+               for src_marker in "${src_markers[@]}"; do
+                   src_dir="`dirname "${src_marker}"`"
+                   src_dir="`readlink -f "${src_dir}/../../"`"
+                   colored_echo yellow "${src_dir}" >&2
+               done
+               return 1
+           fi
+        fi
     elif [ "${1#-}" != "$1" ]; then
         echo syntax j5activate "[framework-src-label]"
         return 1


### PR DESCRIPTION
This handles the build scenario better by finding the repository based on its `j5/src/j5-app.yml` structure rather than assuming it's called `j5-framework` - jenkins uses the step name.

If a parameter is given, it will check for `j5-framework-$1`. Otherwise, it will check for `j5-framework`. If it doesn't exist, and there is exactly one directory parallel to `j5-activate` that contains `j5/src/j5-app.yml`, then it will select that; otherwise, it will print an error message...