### PR TITLE
Do quoting properly in DOS set commands

### DIFF
--- a/bin/j5activate.cmd
+++ b/bin/j5activate.cmd
@@ -6,15 +6,15 @@ if "%1"=="/h" goto usage
 
 if [%1]==[] goto nolabel
 
-set src_dir="%~dp0\..\..\j5-framework-%1"
+set "src_dir=%~dp0\..\..\j5-framework-%1"
 goto :activate
 
 :nolabel
 
-set src_dir="%~dp0\..\..\j5-framework"
+set "src_dir=%~dp0\..\..\j5-framework"
 if exist "%src_dir%" goto :activate
 
-set tmpfile="%tmp%\j5path_%RANDOM%.txt"
+set "tmpfile=%tmp%\j5path_%RANDOM%.txt"
 powershell -NoProfile -ExecutionPolicy unrestricted -File "%~dp0\find_j5_src.ps1" > "%tmpfile%"
 set failure=%errorlevel%
 if %failure% neq 0 (
@@ -22,7 +22,7 @@ if %failure% neq 0 (
   del "%tmpfile%"
   goto :error
 )
-set /p src_dir=<%tmpfile%
+set /p src_dir=<"%tmpfile%"
 del "%tmpfile%"
 echo Found source directory at %src_dir%
 


### PR DESCRIPTION
Putting the quotes around the entire set expression works; otherwise they're treated as part of the value

This causes me problems because my Windows username has a space in it (like my real name)