### PR TITLE
Add support for a --python3 flag to j5activate (on windows)

### DIFF
--- a/bin/j5activate.cmd
+++ b/bin/j5activate.cmd
@@ -3,6 +3,7 @@ if "%1"=="-?" goto usage
 if "%1"=="/?" goto usage
 if "%1"=="-h" goto usage
 if "%1"=="/h" goto usage
+if "%1"=="--python3" goto nolabel
 
 if [%1]==[] goto nolabel
 
@@ -29,11 +30,11 @@ echo Found source directory at %src_dir%
 goto :activate
 
 :activate
-call "%src_dir%\j5\src\Scripts\helpers\j5activate.cmd"
+call "%src_dir%\j5\src\Scripts\helpers\j5activate.cmd" %*
 goto :eof
 
 :usage
-@echo syntax j5activate [framework-src-label]
+@echo syntax j5activate [framework-src-label] [--python3]
 goto :eof
 
 :error


### PR DESCRIPTION
This makes it possible to pass through a --python3 flag to the framework's j5-activate.cmd script so that we can activate a different python environment for py3. 

Older versions just ignore all arguments so it is fine to pass them through.

@davidfraser will follow up with the linux equivalent later on