### PR TITLE
j5activate - support --python3 on linux and better args handling

### DIFF
--- a/bin/j5activate.cmd
+++ b/bin/j5activate.cmd
@@ -1,22 +1,27 @@
 @echo off
+set activate_args=
+set "activate_path=%~dp0"
 if "%1"=="-?" goto usage
 if "%1"=="/?" goto usage
 if "%1"=="-h" goto usage
 if "%1"=="/h" goto usage
-if "%1"=="--python3" goto nolabel
+if "%1"=="--python3" (
+    set activate_args=--python3
+    shift
+)
 
 if [%1]==[] goto nolabel
 
-set "src_dir=%~dp0\..\..\j5-framework-%1"
+set "src_dir=%activate_path%\..\..\j5-framework-%1"
 goto :activate
 
 :nolabel
 
-set "src_dir=%~dp0\..\..\j5-framework"
+set "src_dir=%activate_path%\..\..\j5-framework"
 if exist "%src_dir%" goto :activate
 
 set "tmpfile=%tmp%\j5path_%RANDOM%.txt"
-powershell -NoProfile -ExecutionPolicy unrestricted -File "%~dp0\find_j5_src.ps1" > "%tmpfile%"
+powershell -NoProfile -ExecutionPolicy unrestricted -File "%activate_path%\find_j5_src.ps1" > "%tmpfile%"
 set failure=%errorlevel%
 if %failure% neq 0 (
   type "%tmpfile%" >&2
@@ -25,21 +30,29 @@ if %failure% neq 0 (
 )
 set /p src_dir=<"%tmpfile%"
 del "%tmpfile%"
+set tmpfile=
 echo Found source directory at %src_dir%
 
 goto :activate
 
 :activate
-call "%src_dir%\j5\src\Scripts\helpers\j5activate.cmd" %*
+call "%src_dir%\j5\src\Scripts\helpers\j5activate.cmd" %activate_args%
 if %ERRORLEVEL% GEQ 1 goto :error
 set src_dir=
-goto :eof
+goto :end
 
 :usage
-@echo syntax j5activate [framework-src-label] [--python3]
-goto :eof
+@echo syntax j5activate [--python3] [framework-src-label]
+goto :end
 
 :error
 set src_dir=
 echo j5activate failed >&2
+set activate_path=
+set activate_args=
 exit /b 1
+
+:end
+rem clearing variables
+set activate_path=
+set activate_args=

--- a/bin/j5activate.cmd
+++ b/bin/j5activate.cmd
@@ -10,6 +10,9 @@ if "%1"=="--python3" (
     set activate_args=--python3
     shift
 )
+set "first_arg=%1"
+if "%first_arg:~0,1%"=="-" goto usage
+if "%first_arg:~0,1%"=="/" goto usage
 
 if [%1]==[] goto nolabel
 

--- a/bin/j5activate.cmd
+++ b/bin/j5activate.cmd
@@ -5,6 +5,7 @@ if "%1"=="-?" goto usage
 if "%1"=="/?" goto usage
 if "%1"=="-h" goto usage
 if "%1"=="/h" goto usage
+if "%1"=="--help" goto usage
 if "%1"=="--python3" (
     set activate_args=--python3
     shift

--- a/bin/j5activate.cmd
+++ b/bin/j5activate.cmd
@@ -36,7 +36,7 @@ echo Found source directory at %src_dir%
 goto :activate
 
 :activate
-call "%src_dir%\j5\src\Scripts\helpers\j5activate.cmd" %activate_args%
+call "%src_dir%\j5\src\Scripts\helpers\j5activate.cmd" %* %activate_args%
 if %ERRORLEVEL% GEQ 1 goto :error
 set src_dir=
 goto :end

--- a/bin/j5activate.cmd
+++ b/bin/j5activate.cmd
@@ -56,9 +56,11 @@ set src_dir=
 echo j5activate failed >&2
 set activate_path=
 set activate_args=
+set first_arg=
 exit /b 1
 
 :end
 rem clearing variables
 set activate_path=
 set activate_args=
+set first_arg=

--- a/bin/j5activate.cmd
+++ b/bin/j5activate.cmd
@@ -14,6 +14,7 @@ if "%1"=="--python3" (
 if [%1]==[] goto nolabel
 
 set "src_dir=%activate_path%\..\..\j5-framework-%1"
+if not exist "%src_dir%" echo Could not find j5-framework-%1 >&2 & goto :error
 goto :activate
 
 :nolabel
@@ -21,6 +22,7 @@ goto :activate
 set "src_dir=%activate_path%\..\..\j5-framework"
 if exist "%src_dir%" goto :activate
 
+echo Could not find j5-framework, searching for alternative locations
 set "tmpfile=%tmp%\j5path_%RANDOM%.txt"
 powershell -NoProfile -ExecutionPolicy unrestricted -File "%activate_path%\find_j5_src.ps1" > "%tmpfile%"
 set failure=%errorlevel%

--- a/helpers/enable-j5-activate.sh
+++ b/helpers/enable-j5-activate.sh
@@ -11,7 +11,27 @@ _this_script="`readlink -f "$BASH_SOURCE"`"
 . "$J5_ACTIVATE_HELPERS_DIR/colored-echo.sh"
 
 j5activate() {
-    if [ "$#" == 0 ]; then
+    show_syntax=""
+    target_version=""
+    for arg in "$@"; do
+        case "$arg" in
+            -h|-?|--help)
+               show_syntax=1; shift;;
+            -*)
+               colored_echo red "Unexpected options $arg" >&2
+               show_syntax=1; shift;;
+            [0-9][0-9][.][0-9])
+               [ "$target_version" != "" ] && { colored_echo red "Only one j5 version can be specified" >&2; break; }
+               target_version="$arg"; shift;;
+            *)
+               colored_echo red "Unexpected argument $arg" >&2
+               show_syntax=1; shift;;
+        esac
+    done
+    if [ "$show_syntax" != "" ]; then
+        echo syntax j5activate "[framework-src-label]"
+        return 1
+    elif [ "$target_version" == "" ]; then
         J5DIR="$J5_PARENT_GIT_DIR/j5-framework/j5/src/"
         if [ ! -d "$J5DIR" ]; then
            src_markers=($J5_PARENT_GIT_DIR/*/j5/src/j5-app.yml)
@@ -31,11 +51,8 @@ j5activate() {
                return 1
            fi
         fi
-    elif [ "${1#-}" != "$1" ]; then
-        echo syntax j5activate "[framework-src-label]"
-        return 1
     else
-        J5DIR="$J5_PARENT_GIT_DIR/j5-framework-$1/j5/src/"
+        J5DIR="$J5_PARENT_GIT_DIR/j5-framework-$target_version/j5/src/"
         [ -d "$J5DIR" ] || { colored_echo red "Could not locate j5 framework - $J5DIR does not exist" >&2 ; return 1 ; }
     fi
     if [ -f "$J5DIR/Scripts/j5activate.sh" ]; then

--- a/helpers/enable-j5-activate.sh
+++ b/helpers/enable-j5-activate.sh
@@ -12,11 +12,14 @@ _this_script="`readlink -f "$BASH_SOURCE"`"
 
 j5activate() {
     show_syntax=""
+    activate_args=""
     target_version=""
     for arg in "$@"; do
         case "$arg" in
             -h|-?|--help)
                show_syntax=1; shift;;
+            --python3)
+               activate_args=--python3; shift;;
             -*)
                colored_echo red "Unexpected options $arg" >&2
                show_syntax=1; shift;;
@@ -56,7 +59,7 @@ j5activate() {
         [ -d "$J5DIR" ] || { colored_echo red "Could not locate j5 framework - $J5DIR does not exist" >&2 ; return 1 ; }
     fi
     if [ -f "$J5DIR/Scripts/j5activate.sh" ]; then
-        source "$J5DIR/Scripts/j5activate.sh"
+        source "$J5DIR/Scripts/j5activate.sh" $activate_args
     else
         J5VER=j5-$(grep "^version_code: " $J5DIR/j5-app.yml | sed 's/version_code: \(.*\)/\1/')
         J5_SERVICE_PACK=$(grep "^service_pack_code: " $J5DIR/j5-app.yml | sed 's/service_pack_code: \([0-9][0-9]*\).*$/\1/')


### PR DESCRIPTION
This adds support for the --python3 argument which gets passed through to the underlying j5activate script on Linux
It also supports handling commandline parameters in different orders on Linux
And it adds some better support for re-ordering on Windows (you can say either --python3 28.1 or 28.1 --python3) and gives you usage instructions if you do something odd
And does better error handling