### PR TITLE
Allow j5activate with --python2 flag

### DIFF
--- a/bin/j5activate.cmd
+++ b/bin/j5activate.cmd
@@ -6,8 +6,14 @@ if "%1"=="/?" goto usage
 if "%1"=="-h" goto usage
 if "%1"=="/h" goto usage
 if "%1"=="--help" goto usage
+rem --python3 flag is no longer used and can be removed
+rem but I'm leaving it here for "backwards compatibility" with older commits
 if "%1"=="--python3" (
     set activate_args=--python3
+    shift
+)
+if "%1"=="--python2" (
+    set activate_args=--python2
     shift
 )
 set "first_arg=%1"
@@ -48,7 +54,7 @@ set src_dir=
 goto :end
 
 :usage
-@echo syntax j5activate [--python3] [framework-src-label]
+@echo syntax j5activate [--python2] [framework-src-label]
 goto :end
 
 :error

--- a/helpers/enable-j5-activate.sh
+++ b/helpers/enable-j5-activate.sh
@@ -18,8 +18,12 @@ j5activate() {
         case "$arg" in
             -h|-?|--help)
                show_syntax=1; shift;;
+            # --python3 is no longer use and can be removed
+            # but I'm leaving it here for "backwards-compatibility" with older commits
             --python3)
                activate_args=--python3; shift;;
+            --python2)
+               activate_args=--python2; shift;;
             -*)
                colored_echo red "Unexpected options $arg" >&2
                show_syntax=1; shift;;
@@ -32,7 +36,7 @@ j5activate() {
         esac
     done
     if [ "$show_syntax" != "" ]; then
-        echo syntax j5activate "[framework-src-label]"
+        echo syntax j5activate "[--python2]" "[framework-src-label]"
         return 1
     elif [ "$target_version" == "" ]; then
         J5DIR="$J5_PARENT_GIT_DIR/j5-framework/j5/src/"


### PR DESCRIPTION
We are going to make Python 3 the default. So we need to allow a
--python2 to explicitly specify that we want the Python 2 interpreter.

The related framework changes j5-framework!8595 are still WIP but this PR can be reviewed and merged before the framework MR. 